### PR TITLE
fix `remove` command

### DIFF
--- a/src/commands/Music/remove.js
+++ b/src/commands/Music/remove.js
@@ -32,7 +32,7 @@ module.exports = {
 
     const song = player.queue[position];
 
-    await player.queue.splice(position);
+    await player.queue.splice(position, 1);
 
     const emojieject = client.emoji.remove;
 

--- a/src/slashCommands/Music/remove.js
+++ b/src/slashCommands/Music/remove.js
@@ -45,7 +45,7 @@ module.exports = {
 
     const song = player.queue[position];
 
-    await player.queue.splice(position);
+    await player.queue.splice(position, 1);
 
     const emojieject = client.emoji.remove;
 


### PR DESCRIPTION
The remove command is bugged, Issue #16.

At this [line](https://github.com/Coders-src/WaveMusic/blob/49d192b78437a9265956da1e8e4aab14d4632921/src/commands/Music/remove.js#L35) the splice method is called only with the starting position, which results in the deletion of the elements from starting position to the end of the queue.

